### PR TITLE
SC-213:  trying to reference multiple Resources in a Policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -60,12 +60,17 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: GetParamAccess
+          - Sid: GetSynapseUserKeyParam
             Action:
               - 'ssm:*'
             Effect: Allow
             Resource:
               - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SynapseUserKeyName}'
+          - Sid: GetSynapsePasswordKeyParam
+            Action:
+              - 'ssm:*'
+            Effect: Allow
+            Resource:
               - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SynapsePasswordKeyName}'
 
 Outputs:


### PR DESCRIPTION
Referring to a list of Resources in a Policy in template.yaml resulted in:
```
"Resource": "'arn:aws:ssm:us-east-1:465877038949:parameter/lambda-send-budget-alert/synapse-username'\n'arn:aws:ssm:us-east-1:465877038949:parameter/lambda-send-budget-alert/synapse-password'\n"
```

This PR changes the Policy to use the non-elegant solution of having a separate statement for each Resource.