### PR TITLE
[IT-4003] Auto-update pre-commit hook versions monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  autoupdate_schedule: monthly
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0


### PR DESCRIPTION
Change the frequency that PRs to update pre-commit hook versions are auto-generated from weekly (the default) to monthly.
